### PR TITLE
Use Github action to close or lock unauthorized issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Ensure issue is authorized
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  ensure-issue-authorization:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: exercism/gha-ensure-issue-authorization@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          close-message: |
+            _This repository is restricted to Exercism's core team. Please open issues in github.com/exercism/exercism._
+          lock-message: |
+            _This issue outlines an Exercism project. As with all issues in the `exercism/wip` repo, this is an internal issue restricted to the core team. If you have something you need to discuss on this please open an issue at https://github.com/exercism/exercism._
+          lock-on-permission: write
+          close-on-permission: read


### PR DESCRIPTION
Closes https://github.com/exercism/wip/issues/36.
Closes https://github.com/exercism/wip/issues/34.